### PR TITLE
remove extra version key

### DIFF
--- a/build/release_notes/0.21.0-beta.txt
+++ b/build/release_notes/0.21.0-beta.txt
@@ -1,1 +1,2 @@
 * strip curly braces during extract.
+* clean up default properties in shrendd.

--- a/main/shrendd
+++ b/main/shrendd
@@ -65,7 +65,6 @@ shrendd:
     src: https://github.com/gtque/shrendd/releases/latest/download/${GET_ARTIFACT}
 #   below is an example of getting a specific version, as a reminder of how to specify a specific version
 #    src: "https://github.com/gtque/shrendd/releases/download/v$(shrenddOrDefault shrendd.version)/${GET_ARTIFACT}"
-  version: latest
   default:
     action: render
     template:


### PR DESCRIPTION
* clean up default shrendd properties by removing the extra version key.